### PR TITLE
Only reload active tabs when enabling/disabling the mask

### DIFF
--- a/src/background_script.js
+++ b/src/background_script.js
@@ -38,7 +38,7 @@ async function contentScriptSetup() {
   setupOnBeforeSendHeaders();
 
   const changedHostnames = [...hostsToAdd, ...hostsToRemove];
-  const affectedTabs = await browser.tabs.query({ url: matchPatternsForHostnames(changedHostnames) });
+  const affectedTabs = await browser.tabs.query({ url: matchPatternsForHostnames(changedHostnames), active: true });
   for (const tab of affectedTabs) {
     browser.tabs.reload(tab.id, { bypassCache: true });
   }


### PR DESCRIPTION
I know I have a problem with hoarding too many tabs, but most of the time most of my tabs are discarded. But when testing out this add-on, I "accidentally" clicked the fancy button on a website where I have a LOT of tabs open, and not only did it start reloading tabs from the same domain which were in the background, but it also started loading all the tabs that were discarded, until I ran out of RAM.

My expected behavior would be, that it only reloads the tab from where I'm clicking the button (this is what enabling/disabling the Firefox privacy protection does, and also other add-ons like Dark Reader do).

This change does still not quite that, as it just adds a filter to the query to only find active tabs. If you have the same website open in multiple windows, it would still reload them in all of the open windows, as long as it's the active selected tab in all of the windows. But I think this is an easy solution without adding too much complexity and should solve the problem good enough so it shouldn't cause issues anymore. As even if you would have a lot of windows, all tabs already would need to be loaded, so it can't start reloading discarded tabs.