### PR TITLE
Fix #14 action default title id name

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -25,7 +25,7 @@
   },
   "browser_action": {
     "default_icon": "assets/badge-indicator-off.svg",
-    "default_title": "__MSG_maskStatusOff",
+    "default_title": "__MSG_maskStatusOff__",
     "default_popup": "popup.html",
     "default_area": "navbar"
   },


### PR DESCRIPTION
There was a typo for the default action title that prevented the addon to get the right localized string. 