### PR TITLE
Disable slider when scheme is moz-extension: or about:

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -33,5 +33,9 @@
 
   "maskStatusOff": {
     "message": "Die Maske ist inaktiv! Die Seite sieht mich als Firefox."
+  },
+
+  "maskStatusUnsupported": {
+    "message": "Die Maske kann auf dieser Seite nicht funktionieren."
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -33,5 +33,9 @@
 
   "maskStatusOff": {
     "message": "The mask is off. I look like Firefox to this site."
+  },
+
+  "maskStatusUnsupported": {
+    "message": "The mask cannot work on this site."
   }
 }

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -33,5 +33,9 @@
 
   "maskStatusOff": {
     "message": "Le masque est désactivé. Je ressemble à Firefox pour ce site."
+  },
+
+  "maskStatusUnsupported": {
+    "message": "Le masque ne peut pas fonctionner sur ce site."
   }
 }

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -33,5 +33,9 @@
 
   "maskStatusOff": {
     "message": "Maska jest wyłączona. Na tej stronie wyglądam jak Firefox."
+  },
+
+  "maskStatusUnsupported": {
+    "message": "Maska nie może działać na tej stronie."
   }
 }

--- a/src/popup.js
+++ b/src/popup.js
@@ -11,14 +11,20 @@ async function getActiveTab() {
 
 async function updateUiState() {
   const activeTab = await getActiveTab();
-  const currentHostname = new URL(activeTab.url).hostname;
+  const currentUrl = new URL(activeTab.url);
+  const currentProtocol = currentUrl.protocol;
+  const currentHostname = currentUrl.hostname;
   const maskStatus = document.getElementById("maskStatus");
+  const fancyContainer = document.querySelector("section.fancy_toggle_container");
   const checkbox = document.getElementById("mask_enabled");
   const webcompatLink = document.createElement("a");
   const bugzillaLink = document.createElement("a");
   const reportBrokenSite = document.getElementById("reportBrokenSite");
 
-  if (enabledHostnames.contains(currentHostname)) {
+  if (currentProtocol == "moz-extension:" || currentHostname == "") {
+    maskStatus.innerText = browser.i18n.getMessage("maskStatusUnsupported");
+    fancyContainer.style.display = "none";
+  } else if (enabledHostnames.contains(currentHostname)) {
     maskStatus.innerText = browser.i18n.getMessage("maskStatusOn");
     checkbox.checked = true;
   } else {


### PR DESCRIPTION
Fix issue #23.

A relevant message (maskStatusUnsupported) will be shown and the slider will be disabled when the scheme is moz-extension: or about:. The non-English maskStatusUnsupported messages were translated using Google so these translations need to be proofread before merging this PR.