### PR TITLE
add options page showing enabled hostnames

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "webext-lint": "npx web-ext lint -s src/"
   },
   "devDependencies": {
-    "prettier": "3.3.2",
-    "web-ext": "8.2.0"
+    "prettier": "3.5.3",
+    "web-ext": "8.4.0"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "3.606.0"
+    "@aws-sdk/client-s3": "3.758.0"
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -39,15 +39,15 @@
     "message": "The mask cannot work on this site."
   },
 
-  "siteListTitle": {
-    "message": "Site List"
+  "maskedSitesTitle": {
+    "message": "Currently Masked Sites"
   },
 
-  "siteListDescription": {
-    "message": "This is a list of websites where the mask is enabled."
+  "siteListRemoveButton": {
+    "message": "Remove"
   },
 
   "siteListEmpty": {
-    "message": "Your list is empty."
+    "message": "You did not enable Chrome Mask on any site yet!"
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -37,5 +37,17 @@
 
   "maskStatusUnsupported": {
     "message": "The mask cannot work on this site."
+  },
+
+  "siteListTitle": {
+    "message": "Site List"
+  },
+
+  "siteListDescription": {
+    "message": "This is a list of websites where the mask is enabled."
+  },
+
+  "siteListEmpty": {
+    "message": "Your list is empty."
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -39,6 +39,26 @@
     "message": "The mask cannot work on this site."
   },
 
+  "addSiteTitle": {
+    "message": "Add Site"
+  },
+
+  "addSiteButton": {
+    "message": "Add Site"
+  },
+
+  "addSiteHostnameExplanation": {
+    "message": "Note: Always enter the full domain name. If you enter example.com, Chrome Mask will not be active on www.example.com!"
+  },
+
+  "addSiteErrorInvalid": {
+    "message": "Please enter a valid domain!"
+  },
+
+  "addSiteErrorAlreadyActive": {
+    "message": "Chrome Mask is already enabled for this domain!"
+  },
+
   "maskedSitesTitle": {
     "message": "Currently Masked Sites"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -39,6 +39,14 @@
     "message": "The mask cannot work on this site."
   },
 
+  "manageSitesButton": {
+    "message": "Add or remove sites"
+  },
+
+  "manageSitesFallback": {
+    "message": "To add or remove sites, please open the Extension Manager, select Chrome Mask, and hit Settings."
+  },
+
   "addSiteTitle": {
     "message": "Add Site"
   },

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -31,5 +31,8 @@
   },
   "background": {
     "scripts": ["shared.js", "background_script.js"]
+  },
+  "options_ui": {
+    "page": "options.html"
   }
 }

--- a/src/options.css
+++ b/src/options.css
@@ -1,22 +1,6 @@
-:root {
-  --background-color: #42414c;
-  --border-color: #717079;
-  --color: #fff;
-  --background-alternate-color: #5f5e68;
-
-  @media (prefers-color-scheme: light) {
-    --background-color: #fff;
-    --border-color: #c4c4c5;
-    --color: #15141a;
-    --toggle-background: #e2e2e3;
-  }
-}
-
 body {
-  background-color: var(--background-color);
-  color: var(--color);
   font-family: sans-serif;
-  padding: 0 0.5rem;
+  padding: 0.5rem 1rem;
 }
 
 h2 {
@@ -24,12 +8,14 @@ h2 {
   margin: 0.5rem 0;
 }
 
-p {
-  font-size: 1rem;
-  margin: 0.5rem 0;
-}
+.site-list-item {
+  display: grid;
+  grid-template-columns: 1fr min-content;
+  margin-top: 1rem;
 
-ul {
-  margin: 0.5rem 2rem;
-  padding: 0;
+  p {
+    font-size: 1rem;
+    line-height: 2.5rem;
+    margin: 0;
+  }
 }

--- a/src/options.css
+++ b/src/options.css
@@ -1,21 +1,38 @@
+* {
+  box-sizing: border-box;
+}
+
 body {
   font-family: sans-serif;
-  padding: 0.5rem 1rem;
+  padding: 0.5rem 1rem 2rem;
 }
 
 h2 {
   font-size: 1.3rem;
-  margin: 0.5rem 0;
+  margin: 1.5rem 0 0.5rem;
 }
 
+p {
+  line-height: 1.5rem;
+}
+
+#add-site-form,
 .site-list-item {
   display: grid;
+  gap: 1rem;
   grid-template-columns: 1fr min-content;
   margin-top: 1rem;
 
-  p {
+  p,
+  button,
+  input {
     font-size: 1rem;
     line-height: 2.5rem;
     margin: 0;
+  }
+
+  button,
+  input {
+    padding: 0 0.5rem;
   }
 }

--- a/src/options.css
+++ b/src/options.css
@@ -1,0 +1,35 @@
+:root {
+  --background-color: #42414c;
+  --border-color: #717079;
+  --color: #fff;
+  --background-alternate-color: #5f5e68;
+
+  @media (prefers-color-scheme: light) {
+    --background-color: #fff;
+    --border-color: #c4c4c5;
+    --color: #15141a;
+    --toggle-background: #e2e2e3;
+  }
+}
+
+body {
+  background-color: var(--background-color);
+  color: var(--color);
+  font-family: sans-serif;
+  padding: 0 0.5rem;
+}
+
+h2 {
+  font-size: 1.3rem;
+  margin: 0.5rem 0;
+}
+
+p {
+  font-size: 1rem;
+  margin: 0.5rem 0;
+}
+
+ul {
+  margin: 0.5rem 2rem;
+  padding: 0;
+}

--- a/src/options.html
+++ b/src/options.html
@@ -10,6 +10,14 @@
   </head>
   <body>
     <section>
+      <h2 id="add-site-title"></h2>
+      <form id="add-site-form">
+        <input id="add-site-input" type="text" placeholder="www.example.com" />
+        <input type="submit" id="add-site-button" />
+      </form>
+      <p id="add-site-hostname-explanation"></p>
+    </section>
+    <section>
       <h2 id="masked-sites-title"></h2>
       <div id="masked-sites"></div>
     </section>

--- a/src/options.html
+++ b/src/options.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="options.css" />
+    <script src="shared.js"></script>
+    <script src="options.js"></script>
+  </head>
+  <body>
+    <h2 id="site-list-title">Enabled Hostnames</h2>
+    <p id="site-list-description"></p>
+    <ul id="site-list"></ul>
+  </body>
+</html>

--- a/src/options.html
+++ b/src/options.html
@@ -3,13 +3,15 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark light" />
     <link rel="stylesheet" href="options.css" />
     <script src="shared.js"></script>
     <script src="options.js"></script>
   </head>
   <body>
-    <h2 id="site-list-title">Enabled Hostnames</h2>
-    <p id="site-list-description"></p>
-    <ul id="site-list"></ul>
+    <section>
+      <h2 id="masked-sites-title"></h2>
+      <div id="masked-sites"></div>
+    </section>
   </body>
 </html>

--- a/src/options.js
+++ b/src/options.js
@@ -1,0 +1,38 @@
+const enabledHostnames = new EnabledHostnamesList();
+
+async function updateUiState() {
+  const siteList = document.getElementById("site-list");
+  const siteListTitle = document.getElementById("site-list-title");
+  const siteListDescription = document.getElementById("site-list-description");
+
+  siteListTitle.innerText = browser.i18n.getMessage("siteListTitle");
+  siteListDescription.innerText = browser.i18n.getMessage("siteListDescription");
+
+  if (enabledHostnames.size() > 0) {
+    enabledHostnames.get_values().forEach((hostname) => {
+      const siteListItem = document.createElement("li");
+      siteListItem.textContent = hostname;
+      siteList.appendChild(siteListItem);
+    });
+  } else {
+    const siteListItem = document.createElement("p");
+    siteListItem.innerText = browser.i18n.getMessage("siteListEmpty");
+    siteList.appendChild(siteListItem);
+  }
+}
+
+document.addEventListener("DOMContentLoaded", async () => {
+  await enabledHostnames.load();
+  await updateUiState();
+
+  browser.runtime.onMessage.addListener(async (msg) => {
+    switch (msg.action) {
+      case "enabled_hostnames_changed":
+        await updateUiState();
+        window.location.reload();
+        break;
+      default:
+        throw new Error("unexpected message received", msg);
+    }
+  });
+});

--- a/src/options.js
+++ b/src/options.js
@@ -1,9 +1,52 @@
 const enabledHostnames = new EnabledHostnamesList();
 
-async function updateUiState() {
-  document.getElementById("masked-sites-title").innerText = browser.i18n.getMessage("maskedSitesTitle");
+async function initUi() {
+  [
+    ["add-site-hostname-explanation", "addSiteHostnameExplanation"],
+    ["add-site-title", "addSiteTitle"],
+    ["masked-sites-title", "maskedSitesTitle"],
+  ].forEach(([id, i18nKey]) => {
+    document.getElementById(id).innerText = browser.i18n.getMessage(i18nKey);
+  });
 
+  document.getElementById("add-site-button").value = browser.i18n.getMessage("addSiteButton");
+
+  setupAddForm();
   setupSiteList();
+}
+
+function tryValidateHostname(input) {
+  if (URL.canParse(input)) {
+    return URL.parse(input).hostname;
+  }
+
+  if (URL.canParse(`https://${input}`)) {
+    return URL.parse(`https://${input}`).hostname;
+  }
+
+  return undefined;
+}
+
+function setupAddForm() {
+  const inputEl = document.getElementById("add-site-input");
+  document.getElementById("add-site-form").addEventListener("submit", async (ev) => {
+    ev.preventDefault();
+
+    const maybeHostname = tryValidateHostname(inputEl.value);
+    if (!maybeHostname) {
+      alert(browser.i18n.getMessage("addSiteErrorInvalid"));
+      return false;
+    }
+
+    if (enabledHostnames.contains(maybeHostname)) {
+      alert(browser.i18n.getMessage("addSiteErrorAlreadyActive"));
+      return false;
+    }
+
+    await enabledHostnames.add(maybeHostname);
+    inputEl.value = "";
+    window.location.reload();
+  });
 }
 
 function setupSiteList() {
@@ -30,7 +73,7 @@ function setupSiteList() {
       deleteButton.textContent = browser.i18n.getMessage("siteListRemoveButton");
       deleteButton.addEventListener("click", async () => {
         await enabledHostnames.remove(hostname);
-        await updateUiState();
+        window.location.reload();
       });
 
       siteListItem.append(hostnameLabel, deleteButton);
@@ -40,13 +83,12 @@ function setupSiteList() {
 
 document.addEventListener("DOMContentLoaded", async () => {
   await enabledHostnames.load();
-  await updateUiState();
+  await initUi();
 
   browser.runtime.onMessage.addListener(async (msg) => {
     switch (msg.action) {
       case "enabled_hostnames_changed":
-        await enabledHostnames.load();
-        await updateUiState();
+        window.location.reload();
         break;
       default:
         throw new Error("unexpected message received", msg);

--- a/src/options.js
+++ b/src/options.js
@@ -1,24 +1,41 @@
 const enabledHostnames = new EnabledHostnamesList();
 
 async function updateUiState() {
-  const siteList = document.getElementById("site-list");
-  const siteListTitle = document.getElementById("site-list-title");
-  const siteListDescription = document.getElementById("site-list-description");
+  document.getElementById("masked-sites-title").innerText = browser.i18n.getMessage("maskedSitesTitle");
 
-  siteListTitle.innerText = browser.i18n.getMessage("siteListTitle");
-  siteListDescription.innerText = browser.i18n.getMessage("siteListDescription");
+  setupSiteList();
+}
 
-  if (enabledHostnames.size() > 0) {
-    enabledHostnames.get_values().forEach((hostname) => {
-      const siteListItem = document.createElement("li");
-      siteListItem.textContent = hostname;
-      siteList.appendChild(siteListItem);
-    });
-  } else {
+function setupSiteList() {
+  const siteList = document.getElementById("masked-sites");
+  siteList.innerHTML = "";
+
+  if (enabledHostnames.size() < 1) {
     const siteListItem = document.createElement("p");
     siteListItem.innerText = browser.i18n.getMessage("siteListEmpty");
     siteList.appendChild(siteListItem);
+    return;
   }
+
+  [...enabledHostnames.get_values()]
+    .sort((a, b) => a.localeCompare(b))
+    .forEach((hostname) => {
+      const siteListItem = document.createElement("div");
+      siteListItem.classList.add("site-list-item");
+
+      const hostnameLabel = document.createElement("p");
+      hostnameLabel.textContent = hostname;
+
+      const deleteButton = document.createElement("button");
+      deleteButton.textContent = browser.i18n.getMessage("siteListRemoveButton");
+      deleteButton.addEventListener("click", async () => {
+        await enabledHostnames.remove(hostname);
+        await updateUiState();
+      });
+
+      siteListItem.append(hostnameLabel, deleteButton);
+      siteList.appendChild(siteListItem);
+    });
 }
 
 document.addEventListener("DOMContentLoaded", async () => {
@@ -28,8 +45,8 @@ document.addEventListener("DOMContentLoaded", async () => {
   browser.runtime.onMessage.addListener(async (msg) => {
     switch (msg.action) {
       case "enabled_hostnames_changed":
+        await enabledHostnames.load();
         await updateUiState();
-        window.location.reload();
         break;
       default:
         throw new Error("unexpected message received", msg);

--- a/src/popup.css
+++ b/src/popup.css
@@ -91,3 +91,9 @@ hr {
     }
   }
 }
+
+button {
+  display: block;
+  line-height: 1.5rem;
+  width: 100%;
+}

--- a/src/popup.html
+++ b/src/popup.html
@@ -16,6 +16,13 @@
       </label>
     </section>
     <hr />
+    <section id="manageSites">
+      <button id="manageSitesButton"></button>
+    </section>
+    <section id="manageSitesFallback" style="display: none">
+      <p id="manageSitesFallbackText"></p>
+    </section>
+    <hr />
     <p id="reportBrokenSite"></p>
   </body>
 </html>

--- a/src/popup.js
+++ b/src/popup.js
@@ -48,6 +48,24 @@ async function updateUiState() {
     webcompatLink.outerHTML,
     bugzillaLink.outerHTML,
   ]);
+
+  // Annoyingly, on Android, `browser.runtime.openOptionsPage` is fundamentally
+  // broken. For this to be viable, I'd need two bugs fixed:
+  //   - https://bugzilla.mozilla.org/show_bug.cgi?id=1795449
+  //   - https://bugzilla.mozilla.org/show_bug.cgi?id=1884550
+  // So for now, just display a fallback text for Android... :(
+  const platformInfo = await browser.runtime.getPlatformInfo();
+  if (platformInfo.os == "android") {
+    document.getElementById("manageSites").style.display = "none";
+    document.getElementById("manageSitesFallbackText").innerText = browser.i18n.getMessage("manageSitesFallback");
+    document.getElementById("manageSitesFallback").style.display = "block";
+  } else {
+    const manageSitesButton = document.getElementById("manageSitesButton");
+    manageSitesButton.innerText = browser.i18n.getMessage("manageSitesButton");
+    manageSitesButton.addEventListener("click", async () => {
+      await browser.runtime.openOptionsPage();
+    });
+  }
 }
 
 function linkWithSearch(base, searchParamsInit) {

--- a/src/shared.js
+++ b/src/shared.js
@@ -67,7 +67,7 @@ class ChromeUAStringManager {
 
   // This are just fallbacks in the case we somehow have to make a request before everything is loaded.
   #currentPlatform = "win";
-  #currentUAString = `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36`;
+  #currentUAString = `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36`;
 
   async init() {
     const platformInfo = await browser.runtime.getPlatformInfo();
@@ -89,7 +89,7 @@ class ChromeUAStringManager {
   }
 
   async buildUAStringFromStorage() {
-    let currentChromeVersion = "126";
+    let currentChromeVersion = "134";
 
     const storedMajorVersion = (await browser.storage.local.get("remoteStorageVersionNumber"))
       ?.remoteStorageVersionNumber?.version;

--- a/src/shared.js
+++ b/src/shared.js
@@ -60,6 +60,10 @@ class EnabledHostnamesList {
   get_values() {
     return this.#set.values();
   }
+
+  size() {
+    return this.#set.size;
+  }
 }
 
 class ChromeUAStringManager {


### PR DESCRIPTION
This patch shows a static list of the enabled hostnames in the options page of Chrome Mask under about:addons.