### PR TITLE
Add export and import features

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -91,6 +91,19 @@
     "message": "Export to file"
   },
 
+  "manageSitesImportButton": {
+    "message": "Import from file"
+  },
+
+  "manageSitesImportError": {
+    "message": "[Error] Line $LINE$: Invalid domain name",
+    "placeholders": {
+      "LINE": {
+        "content": "$1"
+      }
+    }
+  },
+
   "exportSitesDefaultFileName": {
     "message": "chrome-mask-sites_$DATETIME$.txt",
     "placeholders": {

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -82,6 +82,24 @@
   "siteListEmpty": {
     "message": "You did not enable Chrome Mask on any site yet!"
   },
+
+  "manageSitesTitle": {
+    "message": "Manage Masked Sites"
+  },
+
+  "manageSitesExportButton": {
+    "message": "Export to file"
+  },
+
+  "exportSitesDefaultFileName": {
+    "message": "chrome-mask-sites_$DATETIME$.txt",
+    "placeholders": {
+      "DATETIME": {
+        "content": "$1"
+      }
+    }
+  },
+
   "shortcutsTitle": {
     "message": "Keyboard Shortcuts"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -95,6 +95,14 @@
     "message": "Import from file"
   },
 
+  "manageSitesClearButton": {
+    "message": "Remove all sites"
+  },
+
+  "manageSitesClearConfirmation": {
+    "message": "Do you want to remove all masked sites?"
+  },
+
   "manageSitesImportError": {
     "message": "[Error] Line $LINE$: Invalid domain name",
     "placeholders": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -19,7 +19,7 @@
       "strict_min_version": "115.0"
     }
   },
-  "permissions": ["storage", "tabs", "webRequest", "webRequestBlocking", "<all_urls>"],
+  "permissions": ["downloads", "storage", "tabs", "webRequest", "webRequestBlocking", "<all_urls>"],
   "icons": {
     "32": "assets/icon-32.png",
     "48": "assets/icon-48.png",

--- a/src/options.css
+++ b/src/options.css
@@ -57,3 +57,9 @@ input {
     margin: 0;
   }
 }
+
+#manage-sites {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1rem;
+}

--- a/src/options.html
+++ b/src/options.html
@@ -26,6 +26,7 @@
       <div id="manage-sites">
         <button id="manage-sites-export-button"></button>
         <button id="manage-sites-import-button"></button>
+        <button id="manage-sites-clear-button"></button>
         <input id="manage-sites-import-filepicker" type="file" accept="text/plain" style="display: none" />
       </div>
     </section>

--- a/src/options.html
+++ b/src/options.html
@@ -21,6 +21,12 @@
       <h2 id="masked-sites-title"></h2>
       <div id="masked-sites"></div>
     </section>
+    <section>
+      <h2 id="manage-sites-title"></h2>
+      <div id="manage-sites">
+        <button id="manage-sites-export-button"></button>
+      </div>
+    </section>
     <section id="shortcuts-section" style="display: none">
       <h2 id="shortcuts-title"></h2>
       <table id="shortcuts-table">

--- a/src/options.html
+++ b/src/options.html
@@ -25,6 +25,8 @@
       <h2 id="manage-sites-title"></h2>
       <div id="manage-sites">
         <button id="manage-sites-export-button"></button>
+        <button id="manage-sites-import-button"></button>
+        <input id="manage-sites-import-filepicker" type="file" accept="text/plain" style="display: none" />
       </div>
     </section>
     <section id="shortcuts-section" style="display: none">

--- a/src/options.js
+++ b/src/options.js
@@ -5,6 +5,7 @@ async function initUi() {
     ["add-site-hostname-explanation", "addSiteHostnameExplanation"],
     ["add-site-title", "addSiteTitle"],
     ["masked-sites-title", "maskedSitesTitle"],
+    ["manage-sites-title", "manageSitesTitle"],
   ].forEach(([id, i18nKey]) => {
     document.getElementById(id).innerText = browser.i18n.getMessage(i18nKey);
   });
@@ -13,6 +14,7 @@ async function initUi() {
 
   setupAddForm();
   setupSiteList();
+  setupManageSites();
   setupKeyboardShortcuts();
 }
 
@@ -81,6 +83,37 @@ function setupSiteList() {
       siteListItem.append(hostnameLabel, deleteButton);
       siteList.appendChild(siteListItem);
     });
+}
+
+function getExportDefaultFileName() {
+  const now = new Date(Date.now() - new Date().getTimezoneOffset() * 60000);
+  const datetime = now
+    .toISOString()
+    .replace(/\.\d+Z$/, "")
+    .replace("T", "_")
+    .replace(/:/g, ".");
+  return browser.i18n.getMessage("exportSitesDefaultFileName", [datetime]);
+}
+
+function setupManageSites() {
+  const manageSitesExportButton = document.getElementById("manage-sites-export-button");
+  manageSitesExportButton.textContent = browser.i18n.getMessage("manageSitesExportButton");
+
+  if (enabledHostnames.size() < 1) {
+    manageSitesExportButton.disabled = true;
+    return;
+  }
+
+  manageSitesExportButton.addEventListener("click", async () => {
+    const fileContent = [...enabledHostnames.get_values()].sort((a, b) => a.localeCompare(b)).join("\n");
+    const blob = new Blob([fileContent], { type: "text/plain;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    browser.downloads.download({
+      url: url,
+      filename: getExportDefaultFileName(),
+      saveAs: true,
+    });
+  });
 }
 
 async function setupKeyboardShortcuts() {

--- a/src/options.js
+++ b/src/options.js
@@ -85,6 +85,44 @@ function setupSiteList() {
     });
 }
 
+function handleImportFilepicker(ev) {
+  const fileReaderOnLoadHandler = async function () {
+    let result = this.result;
+    if (typeof this.result !== "string" || this.result === "") {
+      return;
+    }
+    const lines = result.split(/\r?\n/);
+    for (const [index, val] of lines.entries()) {
+      if (val === "") {
+        continue;
+      }
+      const maybeHostname = tryValidateHostname(val);
+      if (!maybeHostname) {
+        alert(browser.i18n.getMessage("manageSitesImportError", [index + 1]));
+        window.location.reload();
+        break;
+      }
+
+      if (enabledHostnames.contains(maybeHostname)) {
+        continue;
+      }
+
+      await enabledHostnames.add(maybeHostname);
+    }
+    window.location.reload();
+  };
+  const file = ev.target.files[0];
+  if (file === undefined || file.name === "") {
+    return;
+  }
+  if (file.type.indexOf("text") !== 0) {
+    return;
+  }
+  const fr = new FileReader();
+  fr.addEventListener("load", fileReaderOnLoadHandler);
+  fr.readAsText(file);
+}
+
 function getExportDefaultFileName() {
   const now = new Date(Date.now() - new Date().getTimezoneOffset() * 60000);
   const datetime = now
@@ -98,6 +136,18 @@ function getExportDefaultFileName() {
 function setupManageSites() {
   const manageSitesExportButton = document.getElementById("manage-sites-export-button");
   manageSitesExportButton.textContent = browser.i18n.getMessage("manageSitesExportButton");
+
+  const manageSitesImportButton = document.getElementById("manage-sites-import-button");
+  manageSitesImportButton.textContent = browser.i18n.getMessage("manageSitesImportButton");
+  manageSitesImportButton.addEventListener("click", async () => {
+    const input = document.getElementById("manage-sites-import-filepicker");
+    input.click();
+  });
+
+  const manageSitesImportFilepicker = document.getElementById("manage-sites-import-filepicker");
+  manageSitesImportFilepicker.addEventListener("change", async (ev) => {
+    handleImportFilepicker(ev);
+  });
 
   if (enabledHostnames.size() < 1) {
     manageSitesExportButton.disabled = true;

--- a/src/options.js
+++ b/src/options.js
@@ -137,6 +137,9 @@ function setupManageSites() {
   const manageSitesExportButton = document.getElementById("manage-sites-export-button");
   manageSitesExportButton.textContent = browser.i18n.getMessage("manageSitesExportButton");
 
+  const manageSitesClearButton = document.getElementById("manage-sites-clear-button");
+  manageSitesClearButton.textContent = browser.i18n.getMessage("manageSitesClearButton");
+
   const manageSitesImportButton = document.getElementById("manage-sites-import-button");
   manageSitesImportButton.textContent = browser.i18n.getMessage("manageSitesImportButton");
   manageSitesImportButton.addEventListener("click", async () => {
@@ -151,6 +154,7 @@ function setupManageSites() {
 
   if (enabledHostnames.size() < 1) {
     manageSitesExportButton.disabled = true;
+    manageSitesClearButton.disabled = true;
     return;
   }
 
@@ -163,6 +167,14 @@ function setupManageSites() {
       filename: getExportDefaultFileName(),
       saveAs: true,
     });
+  });
+
+  manageSitesClearButton.addEventListener("click", async () => {
+    const userChoice = confirm(browser.i18n.getMessage("manageSitesClearConfirmation"));
+    if (userChoice) {
+      await enabledHostnames.clear();
+      window.location.reload();
+    }
   });
 }
 

--- a/src/shared.js
+++ b/src/shared.js
@@ -53,6 +53,11 @@ class EnabledHostnamesList {
     await this.#persist();
   }
 
+  async clear() {
+    this.#set.clear();
+    await this.#persist();
+  }
+
   contains(hostname) {
     return this.#set.has(hostname);
   }


### PR DESCRIPTION
This adds the ability to export and import masked domain names, per this feature request in #72. Three buttons, namely "Export to file", "Import from file", and "Remove all sites" are added to a new section in the option page.
<img width="423" height="316" alt="image" src="https://github.com/user-attachments/assets/c515de6c-e0d2-40b6-ab11-8bf3e6874779" />

### Export to file
Exported domain names are saved as a text file (default name: chrome-mask-sites_YYYY-MM-DD_HH.MM.SS), with every domain name on a new line. The downloads permission in manifest.json is needed to trigger the native file download popup during export.

### Import from file
Importing a file appends only new domain names in the file to existing masked ones. Currently, added domain names are not being sanitised beyond calling the existing tryValidateHostname() function or checking if they exist already, so this might be an issue.

### Remove all sites
This clears all currently masked sites. Because importing a file only appends new domain names to existing ones, this is more of a QoL feature when an user wants to import a file to a clean slate.